### PR TITLE
Clarify inherited props from View in WebView docs

### DIFF
--- a/docs/webview.md
+++ b/docs/webview.md
@@ -27,7 +27,7 @@ You can use this component to navigate back and forth in the web view's history 
 
 ### Props
 
-* [View props...](view.md#props)
+* [Inherited props from View...](view.md#props)
 
 - [`source`](webview.md#source)
 - [`automaticallyAdjustContentInsets`](webview.md#automaticallyadjustcontentinsets)


### PR DESCRIPTION
In an effort to avoid confusion and clarify what exactly is shown on the props from `View` page, this rephrases the link a little.

The previous text gives the impression that it displays all the `WebView` props in a dedicated page, when in fact it's the props for `View` which `WebView` has inherited.

Worst case one might wonder why the `WebView` does not have a prop for specifying the URL as the `View` props list does not have anything related.

Any thoughts? If this makes sense, I'll happily change the other similar links throughout the site.